### PR TITLE
improved write support for large files

### DIFF
--- a/cc3200tool/cc.py
+++ b/cc3200tool/cc.py
@@ -623,9 +623,6 @@ class CC3200Connection(object):
         timeout = self.port.timeout
         if (alloc_size > 200000):
             timeout = max(timeout, 5 * ((alloc_size / 200000) + 1)) # empirical value is ~252925 bytes for 5 sec timeout
-            if timeout != self.port.timeout:
-                #log.info("File is large, increased timeout %d -> %d", self.port.timeout, timeout)
-				pass
 
         log.info("Uploading file %s -> %s [%d]...",
                 local_file.name, cc_filename, alloc_size)

--- a/cc3200tool/cc.py
+++ b/cc3200tool/cc.py
@@ -284,6 +284,9 @@ class CC3200Connection(object):
         if timeout is None:
             yield self.port
             return
+        if timeout == self.port.timeout:
+            yield self.port
+            return
         orig_timeout, self.port.timeout = self.port.timeout, timeout
         yield self.port
         self.port.timeout = orig_timeout
@@ -616,9 +619,19 @@ class CC3200Connection(object):
             self.erase_file(cc_filename)
 
         alloc_size = max(size, file_len)
+
+        timeout = self.port.timeout
+        if (alloc_size > 200000):
+            timeout = max(timeout, 5 * ((alloc_size / 200000) + 1)) # empirical value is ~252925 bytes for 5 sec timeout
+            if timeout != self.port.timeout:
+                #log.info("File is large, increased timeout %d -> %d", self.port.timeout, timeout)
+				pass
+
         log.info("Uploading file %s -> %s [%d]...",
-                 local_file.name, cc_filename, alloc_size)
-        self._open_file_for_write(cc_filename, alloc_size)
+                local_file.name, cc_filename, alloc_size)
+
+        with self._serial_timeout(timeout):
+            self._open_file_for_write(cc_filename, alloc_size)
 
         pos = 0
         while pos < file_len:


### PR DESCRIPTION
Increases serial port timeout when writing large files (1M).

My guess is that when this tool instructs cc3200 to allocate space for a file (SSFS does not support fragmentation -- that's why I need to allocate space in advance, in particular for OTA-able files), it takes significant time, depending on file size. Files of the size of up to ~250000 work with default timeout=5, but for larger ones cc3200tool has no chance to receive the ACK -- cc3200 is still busy allocating.