### PR TITLE
fix brackets at hexify function

### DIFF
--- a/cc3200tool/cc.py
+++ b/cc3200tool/cc.py
@@ -81,7 +81,7 @@ SLFS_MODE_OPEN_WRITE_CREATE_IF_NOT_EXIST = 3
 
 
 def hexify(s):
-    return " ".join([hex(ord(x) for x in s)])
+    return " ".join([hex(ord(x)) for x in s])
 
 
 Pincfg = namedtuple('Pincfg', ['invert', 'pin'])


### PR DESCRIPTION
Typo error, lead to unability to flash device.