### PR TITLE
Fix pip exe creation on Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,8 @@ setup(
     url="http://github.com/allterco/cc3200tool",
     packages=['cc3200tool'],
     package_data={'cc3200tool': ['dll/*.dll']},
-    scripts=['scripts/cc3200tool'],
+    entry_points = {
+        'console_scripts': ['cc3200tool=cc3200tool.cc:main'],
+    },
     install_requires=['pyserial'],
 )


### PR DESCRIPTION
Slight setup.py modification - currently `pip install` won't give me something I can run just by having it on my PATH.

By using the `console_scripts` functionality it works on Linux *and* Windows, creating a `cc3200tool.exe` that works great.